### PR TITLE
Support multiple document types

### DIFF
--- a/example/demo_client.dart
+++ b/example/demo_client.dart
@@ -27,7 +27,7 @@ void main() {
   print("dart-collab demo");
   editor = query('#editor');
   statusDiv = query('#status');
-  doc = new collab.Document("test");
+  doc = new collab.TextDocument("test");
   String host = window.location.hostname;
   print("host: $host");
 

--- a/example/demo_client.dart
+++ b/example/demo_client.dart
@@ -27,7 +27,7 @@ void main() {
   print("dart-collab demo");
   editor = query('#editor');
   statusDiv = query('#status');
-  doc = new collab.TextDocument("test", "text");
+  doc = new collab.Document("test", "text", new collab.TextContent());
   String host = window.location.hostname;
   print("host: $host");
 

--- a/example/demo_client.dart
+++ b/example/demo_client.dart
@@ -27,7 +27,7 @@ void main() {
   print("dart-collab demo");
   editor = query('#editor');
   statusDiv = query('#status');
-  doc = new collab.Document("test", "text", new collab.TextContent());
+  doc = new collab.TextDocument("test");
   String host = window.location.hostname;
   print("host: $host");
 

--- a/example/demo_client.dart
+++ b/example/demo_client.dart
@@ -27,7 +27,7 @@ void main() {
   print("dart-collab demo");
   editor = query('#editor');
   statusDiv = query('#status');
-  doc = new collab.TextDocument("test");
+  doc = new collab.TextDocument("test", "text");
   String host = window.location.hostname;
   print("host: $host");
 

--- a/example/demo_client.dart
+++ b/example/demo_client.dart
@@ -18,6 +18,7 @@ import 'dart:html';
 import 'package:collab/client/web_client.dart';
 import 'package:collab/client/web_utils.dart';
 import 'package:collab/collab.dart' as collab;
+import 'package:collab/text/text.dart';
 
 TextAreaElement editor;
 collab.Document doc;
@@ -27,7 +28,7 @@ void main() {
   print("dart-collab demo");
   editor = query('#editor');
   statusDiv = query('#status');
-  doc = new collab.TextDocument("test");
+  doc = new TextDocument("test");
   String host = window.location.hostname;
   print("host: $host");
 

--- a/example/demo_server.dart
+++ b/example/demo_server.dart
@@ -27,7 +27,7 @@ void main() {
   host = (host == null) ? "127.0.0.1" : host;
 
   var collabServer = new CollabServer();
-  collabServer.registerDocumentType("text", new TextDocumentType());
+  collabServer.registerDocumentType(new TextDocumentType());
   StreamController sc = new StreamController();
   sc.stream.transform(new WebSocketTransformer()).listen((WebSocket ws) {
     var connection = new WebSocketConnection(ws);

--- a/example/demo_server.dart
+++ b/example/demo_server.dart
@@ -26,7 +26,7 @@ void main() {
   host = (host == null) ? "127.0.0.1" : host;
 
   var collabServer = new CollabServer();
-  collabServer.registerDocumentType("text", TextDocument.factory);
+  collabServer.registerDocumentType("text", new TextDocumentType());
   StreamController sc = new StreamController();
   sc.stream.transform(new WebSocketTransformer()).listen((WebSocket ws) {
     var connection = new WebSocketConnection(ws);

--- a/example/demo_server.dart
+++ b/example/demo_server.dart
@@ -26,6 +26,7 @@ void main() {
   host = (host == null) ? "127.0.0.1" : host;
 
   var collabServer = new CollabServer();
+  collabServer.registerDocumentType("text", textDocFactory);
   StreamController sc = new StreamController();
   sc.stream.transform(new WebSocketTransformer()).listen((WebSocket ws) {
     var connection = new WebSocketConnection(ws);

--- a/example/demo_server.dart
+++ b/example/demo_server.dart
@@ -26,7 +26,7 @@ void main() {
   host = (host == null) ? "127.0.0.1" : host;
 
   var collabServer = new CollabServer();
-  collabServer.registerDocumentType("text", textDocFactory);
+  collabServer.registerDocumentType("text", TextContent.factory);
   StreamController sc = new StreamController();
   sc.stream.transform(new WebSocketTransformer()).listen((WebSocket ws) {
     var connection = new WebSocketConnection(ws);

--- a/example/demo_server.dart
+++ b/example/demo_server.dart
@@ -26,7 +26,7 @@ void main() {
   host = (host == null) ? "127.0.0.1" : host;
 
   var collabServer = new CollabServer();
-  collabServer.registerDocumentType("text", TextContent.factory);
+  collabServer.registerDocumentType("text", TextDocument.factory);
   StreamController sc = new StreamController();
   sc.stream.transform(new WebSocketTransformer()).listen((WebSocket ws) {
     var connection = new WebSocketConnection(ws);

--- a/example/demo_server.dart
+++ b/example/demo_server.dart
@@ -18,6 +18,7 @@ import 'dart:isolate';
 
 import 'package:collab/collab.dart';
 import 'package:collab/server/server.dart';
+import 'package:collab/text/text.dart';
 import 'package:collab/utils.dart';
 
 void main() {

--- a/lib/client/connection.dart
+++ b/lib/client/connection.dart
@@ -28,8 +28,8 @@ class WebSocketConnection implements Connection {
 
   Stream<Message> get stream => _msgTransformer.bind(_socket.onMessage);
   void add(String message) => _socket.send(message);
-  void addStream(Stream<String> stream) => stream.listen((msg) {
-    _socket.send(msg);
-  });
+  void addStream(Stream<String> stream) {
+    stream.listen((msg) => _socket.send(msg));
+  }
   void close() => _socket.close();
 }

--- a/lib/client/connection.dart
+++ b/lib/client/connection.dart
@@ -18,8 +18,7 @@ class WebSocketConnection implements Connection {
   static final _msgTransformer =
       new StreamTransformer(handleData: (value, sink) {
         if (value is html.MessageEvent) {
-          var message = new Message.parse(value.data);
-          sink.add(message);
+          sink.add(value.data);
         }
       });
 
@@ -28,9 +27,9 @@ class WebSocketConnection implements Connection {
   WebSocketConnection(html.WebSocket this._socket);
 
   Stream<Message> get stream => _msgTransformer.bind(_socket.onMessage);
-  void add(Message message) => _socket.send(message.json);
-  void addStream(Stream<Message> stream) => stream.listen((Message msg) {
-    _socket.send(msg.json);
+  void add(String message) => _socket.send(message);
+  void addStream(Stream<String> stream) => stream.listen((msg) {
+    _socket.send(msg);
   });
   void close() => _socket.close();
 }

--- a/lib/client/web_client.dart
+++ b/lib/client/web_client.dart
@@ -53,8 +53,12 @@ class CollabWebClient {
     _statusHandlers = new List<StatusHandler>();
     _onStatusChange(CONNECTING);
 
-    _connection.stream.transform(MSG_TRANSFORMER).listen(
-        (message) {
+    _connection.stream.transform(JSON_TO_MAP).listen(
+        (json) {
+          Message message = SystemMessageParser.parse(json);
+          if (message == null) {
+            message = _document.type.parseMessage(json);
+          }
           _dispatch(message);
         },
         onError: (error) {

--- a/lib/client/web_client.dart
+++ b/lib/client/web_client.dart
@@ -58,7 +58,7 @@ class CollabWebClient {
     _statusHandlers = new List<StatusHandler>();
     _onStatusChange(CONNECTING);
 
-    _connection.stream.transform(JSON_TO_MAP).listen((json) {
+    _connection.stream.transform(jsonToMap).listen((json) {
         var factory = _messageFactories[json['type']];
         Message message = factory(json);
         _dispatch(message);

--- a/lib/client/web_client.dart
+++ b/lib/client/web_client.dart
@@ -174,8 +174,9 @@ class CollabWebClient {
     _clientId = message.clientId;
     print("clientId: $_clientId");
     // once we have a clientId, open a test doc
-    OpenMessage cm = new OpenMessage(_document.id, _document.type, _clientId);
-    send(cm);
+    OpenMessage om =
+        new OpenMessage(_document.id, _document.type.id, _clientId);
+    send(om);
     _onStatusChange(CONNECTED);
   }
 

--- a/lib/client/web_client.dart
+++ b/lib/client/web_client.dart
@@ -174,7 +174,7 @@ class CollabWebClient {
     _clientId = message.clientId;
     print("clientId: $_clientId");
     // once we have a clientId, open a test doc
-    OpenMessage cm = new OpenMessage(_document.id, _clientId);
+    OpenMessage cm = new OpenMessage(_document.id, _document.type, _clientId);
     send(cm);
     _onStatusChange(CONNECTED);
   }

--- a/lib/client/web_client.dart
+++ b/lib/client/web_client.dart
@@ -53,7 +53,7 @@ class CollabWebClient {
     _statusHandlers = new List<StatusHandler>();
     _onStatusChange(CONNECTING);
 
-    _connection.stream.listen(
+    _connection.stream.transform(MSG_TRANSFORMER).listen(
         (message) {
           _dispatch(message);
         },
@@ -86,7 +86,7 @@ class CollabWebClient {
   }
 
   void send(Message message) {
-    _connection.add(message);
+    _connection.add(message.json);
   }
 
   void addStatusHandler(StatusHandler h) {

--- a/lib/client/web_client.dart
+++ b/lib/client/web_client.dart
@@ -110,7 +110,7 @@ class CollabWebClient {
         List toRemove = [];
         _incoming.forEach((Operation i) {
           if (i.sequence < op.sequence) {
-            var it = Operation.transform(i, _pending);
+            var it = _document.type.transform(i, _pending);
             _apply(it);
             toRemove.add(it);
           }

--- a/lib/client/web_client.dart
+++ b/lib/client/web_client.dart
@@ -58,20 +58,19 @@ class CollabWebClient {
     _statusHandlers = new List<StatusHandler>();
     _onStatusChange(CONNECTING);
 
-    _connection.stream.transform(JSON_TO_MAP).listen(
-        (json) {
-          var factory = _messageFactories[json['type']];
-          Message message = factory(json);
-          _dispatch(message);
-        },
-        onError: (error) {
-          _onStatusChange(ERROR);
-          print("error: $error");
-        },
-        onDone: () {
-          _onStatusChange(DISCONNECTED);
-          print("closed");
-        });
+    _connection.stream.transform(JSON_TO_MAP).listen((json) {
+        var factory = _messageFactories[json['type']];
+        Message message = factory(json);
+        _dispatch(message);
+      },
+      onError: (error) {
+        _onStatusChange(ERROR);
+        print("error: $error");
+      },
+      onDone: () {
+        _onStatusChange(DISCONNECTED);
+        print("closed");
+      });
   }
 
   Document get document => _document;

--- a/lib/client/web_client.dart
+++ b/lib/client/web_client.dart
@@ -76,7 +76,7 @@ class CollabWebClient {
   // TODO: change away from send, since only the client can send
   // might need a separate envelope from message
   void queue(Operation operation) {
-    operation.apply(_document.content);
+    operation.apply(_document);
     if (_pending == null) {
       _pending = operation;
       send(operation);
@@ -147,7 +147,7 @@ class CollabWebClient {
   }
 
   void _apply(Operation op) {
-    op.apply(_document.content);
+    op.apply(_document);
     _document.log.add(op);
     if (op.sequence > _document.version) {
       _document.version = op.sequence;
@@ -180,7 +180,7 @@ class CollabWebClient {
   }
 
   void _onSnapshot(SnapshotMessage message) {
-    _document.content.deserialize(message.content);
+    _document.deserialize(message.content);
     _document.version = message.version;
   }
 }

--- a/lib/client/web_client.dart
+++ b/lib/client/web_client.dart
@@ -76,7 +76,7 @@ class CollabWebClient {
   // TODO: change away from send, since only the client can send
   // might need a separate envelope from message
   void queue(Operation operation) {
-    operation.apply(_document);
+    operation.apply(_document.content);
     if (_pending == null) {
       _pending = operation;
       send(operation);
@@ -147,7 +147,7 @@ class CollabWebClient {
   }
 
   void _apply(Operation op) {
-    op.apply(_document);
+    op.apply(_document.content);
     _document.log.add(op);
     if (op.sequence > _document.version) {
       _document.version = op.sequence;
@@ -180,7 +180,7 @@ class CollabWebClient {
   }
 
   void _onSnapshot(SnapshotMessage message) {
-    _document.content = message.content;
+    _document.content.deserialize(message.content);
     _document.version = message.version;
   }
 }

--- a/lib/client/web_client.dart
+++ b/lib/client/web_client.dart
@@ -180,7 +180,7 @@ class CollabWebClient {
   }
 
   void _onSnapshot(SnapshotMessage message) {
-    _document.modify(0, document.text, message.text);
+    _document.content = message.content;
     _document.version = message.version;
   }
 }

--- a/lib/client/web_client.dart
+++ b/lib/client/web_client.dart
@@ -30,7 +30,7 @@ class CollabWebClient {
   String _clientId;
   Document _document;
   Map<String, MessageFactory> _messageFactories;
-  Map<TransformType, Transform> _transforms;
+  Map<String, Map<String, Transform>> _transforms;
   Map<String, Completer> _pendingRequests; // might not be necessary anymore
   List<StatusHandler> _statusHandlers;
 
@@ -48,11 +48,9 @@ class CollabWebClient {
   final Connection _connection;
 
   CollabWebClient(Connection this._connection, Document this._document) {
-    _messageFactories = new Map<String, MessageFactory>();
-    _messageFactories.addAll(_document.type.messageFactories);
+    _messageFactories = new Map.from(_document.type.messageFactories);
     _messageFactories.addAll(SystemMessageFactories.messageFactories);
-    _transforms = new Map<TransformType, Transform>();
-    _transforms.addAll(_document.type.transforms);
+    _transforms = new Map.from(_document.type.transforms);
     _pendingRequests = new Map<String, Completer>();
     _queue = new List<Operation>();
     _incoming = new List<Operation>();
@@ -119,8 +117,7 @@ class CollabWebClient {
         List toRemove = [];
         _incoming.forEach((Operation i) {
           if (i.sequence < op.sequence) {
-            var transform =
-                _transforms[new TransformType(i.type, _pending.type)];
+            var transform = _transforms[i.type][_pending.type];
             var it = (transform == null) ? i : transform(i, _pending);
             _apply(it);
             toRemove.add(it);

--- a/lib/client/web_utils.dart
+++ b/lib/client/web_utils.dart
@@ -118,16 +118,19 @@ void makeEditable(Element element, CollabWebClient client) {
     }
   });
 
-  client.document.addChangeHandler((event) {
+  client.document.addChangeHandler((collab.DocumentChangeEvent docEvent) {
     if (listen) {
       listen = false;
-      int cursorPos = (element as dynamic).selectionStart;
-      (element as dynamic).value = event.text;
-      if (event.position < cursorPos) {
-        cursorPos =
-            max(0, cursorPos + event.inserted.length - event.deleted.length);
+      var e = docEvent.cause;
+      if (e is collab.TextChangeEvent) {
+        int cursorPos = (element as dynamic).selectionStart;
+        (element as dynamic).value = e.text;
+        if (e.position < cursorPos) {
+          cursorPos =
+              max(0, cursorPos + e.inserted.length - e.deleted.length);
+        }
+        (element as dynamic).setSelectionRange(cursorPos, cursorPos);
       }
-      (element as dynamic).setSelectionRange(cursorPos, cursorPos);
       listener.reset();
       listen = true;
     }

--- a/lib/client/web_utils.dart
+++ b/lib/client/web_utils.dart
@@ -118,7 +118,7 @@ void makeEditable(Element element, CollabWebClient client) {
     }
   });
 
-  client.document.addChangeHandler((collab.DocumentChangeEvent event) {
+  client.document.addChangeHandler((event) {
     if (listen) {
       listen = false;
       int cursorPos = (element as dynamic).selectionStart;

--- a/lib/client/web_utils.dart
+++ b/lib/client/web_utils.dart
@@ -17,6 +17,7 @@ library web_utils;
 import 'dart:html';
 import 'dart:math';
 import 'package:collab/collab.dart' as collab;
+import 'package:collab/text/text.dart' as text;
 import 'web_client.dart';
 
 class TextChangeEvent {
@@ -111,7 +112,7 @@ void makeEditable(Element element, CollabWebClient client) {
     print(event);
     if (listen) {
       listen = false;
-      collab.TextOperation op = new collab.TextOperation(client.id, "test",
+      text.TextOperation op = new text.TextOperation(client.id, "test",
           client.docVersion, event.position, event.deleted, event.inserted);
       client.queue(op);
       listen = true;
@@ -119,7 +120,7 @@ void makeEditable(Element element, CollabWebClient client) {
   });
 
   client.document.addChangeHandler((collab.DocumentChangeEvent event) {
-    if (listen && event is collab.TextChangeEvent) {
+    if (listen && event is text.TextChangeEvent) {
       listen = false;
       int cursorPos = (element as dynamic).selectionStart;
       (element as dynamic).value = event.text;

--- a/lib/client/web_utils.dart
+++ b/lib/client/web_utils.dart
@@ -118,19 +118,16 @@ void makeEditable(Element element, CollabWebClient client) {
     }
   });
 
-  client.document.addChangeHandler((collab.DocumentChangeEvent docEvent) {
-    if (listen) {
+  client.document.addChangeHandler((collab.DocumentChangeEvent event) {
+    if (listen && event is collab.TextChangeEvent) {
       listen = false;
-      var e = docEvent.cause;
-      if (e is collab.TextChangeEvent) {
-        int cursorPos = (element as dynamic).selectionStart;
-        (element as dynamic).value = e.text;
-        if (e.position < cursorPos) {
-          cursorPos =
-              max(0, cursorPos + e.inserted.length - e.deleted.length);
-        }
-        (element as dynamic).setSelectionRange(cursorPos, cursorPos);
+      int cursorPos = (element as dynamic).selectionStart;
+      (element as dynamic).value = event.text;
+      if (event.position < cursorPos) {
+        cursorPos =
+            max(0, cursorPos + event.inserted.length - event.deleted.length);
       }
+      (element as dynamic).setSelectionRange(cursorPos, cursorPos);
       listener.reset();
       listen = true;
     }

--- a/lib/collab.dart
+++ b/lib/collab.dart
@@ -24,4 +24,3 @@ part 'message.dart';
 part 'messages.dart';
 part 'document.dart';
 part 'operation.dart';
-part 'text.dart';

--- a/lib/connection.dart
+++ b/lib/connection.dart
@@ -15,8 +15,8 @@
 part of collab;
 
 abstract class Connection {
-  Stream<Message> get stream;
-  void add(Message message);
-  void addStream(Stream<Message> message);
+  Stream get stream;
+  void add(String message);
+  void addStream(Stream<String> message);
   void close();
 }

--- a/lib/document.dart
+++ b/lib/document.dart
@@ -18,6 +18,7 @@ part of collab;
 abstract class DocumentType {
   String get id;
   Document create(String id);
+  Operation transform(Operation op, Operation by);
 }
 
 class DocumentChangeEvent {

--- a/lib/document.dart
+++ b/lib/document.dart
@@ -22,13 +22,16 @@ abstract class DocumentChangeEvent {
 
 typedef void DocumentChangeHandler(DocumentChangeEvent e);
 
+typedef Document DocumentFactory(String id, String type);
+
 abstract class Document {
   final String id;
+  final String type;
   int version;
   final List<Operation> log;
   final List<DocumentChangeHandler> _handlers;
 
-  Document(this.id)
+  Document(this.id, this.type)
     : version = 0,
       log = new List<Operation>(),
       _handlers = new List<DocumentChangeHandler>();
@@ -53,8 +56,15 @@ abstract class Document {
  * not operate on an existing document.
  */
 class CreateMessage extends Message {
-  CreateMessage(String senderId) : super("create", senderId);
-  CreateMessage.fromMap(Map<String, Object> map) : super.fromMap(map);
+  final String docType;
+
+  CreateMessage(this.docType, String senderId) : super("create", senderId);
+
+  CreateMessage.fromMap(Map<String, Object> map)
+    : super.fromMap(map),
+      docType = map['docType'];
+
+  toMap([values]) => super.toMap(mergeMaps(values, {'docType': docType}));
 }
 
 /*
@@ -62,14 +72,17 @@ class CreateMessage extends Message {
  */
 class CreatedMessage extends Message {
   String docId;
-  CreatedMessage(this.docId, [String replyTo])
+  String docType;
+  CreatedMessage(this.docId, this.docType, [String replyTo])
     : super("created", SERVER_ID, replyTo);
 
   CreatedMessage.fromMap(Map<String, Object> map)
     : super.fromMap(map),
-    docId = map['docId'];
+    docId = map['docId'],
+    docType = map['docType'];
 
-  toMap([values]) => super.toMap(mergeMaps(values, {'docId': docId}));
+  toMap([values]) =>
+      super.toMap(mergeMaps(values, {'docId': docId, 'docType': docType}));
 }
 
 /*
@@ -77,14 +90,18 @@ class CreatedMessage extends Message {
  */
 class OpenMessage extends Message {
   final String docId;
+  final String docType;
 
-  OpenMessage(this.docId, String senderId) : super("open", senderId);
+  OpenMessage(this.docId, this.docType, String senderId)
+    : super("open", senderId);
 
   OpenMessage.fromMap(Map<String, Object> map)
     : super.fromMap(map),
-      docId = map['docId'];
+      docId = map['docId'],
+      docType = map['docType'];
 
-  toMap([values]) => super.toMap(mergeMaps(values, {'docId': docId}));
+  toMap([values]) =>
+      super.toMap(mergeMaps(values, {'docId': docId, 'docType': docType}));
 }
 
 /*

--- a/lib/document.dart
+++ b/lib/document.dart
@@ -15,43 +15,27 @@ part of collab;
 //  limitations under the License.
 
 
-abstract class ContentChangeEvent {}
-
-abstract class Content {
-  StreamController<ContentChangeEvent> controller;
-
-  Content()
-    : controller = new StreamController<ContentChangeEvent>();
-
-  String serialize();
-  void deserialize(String data);
-}
-
-typedef Content ContentFactory();
+typedef Document DocumentFactory(String id);
 
 class DocumentChangeEvent {
   final Document document;
-  final ContentChangeEvent cause;
-  DocumentChangeEvent(this.document, this.cause);
+
+  DocumentChangeEvent(this.document);
 }
 
 typedef void DocumentChangeHandler(DocumentChangeEvent e);
 
-class Document {
+abstract class Document {
   final String type;
   final String id;
   int version;
-  final Content content;
   final List<Operation> log;
   final List<DocumentChangeHandler> _handlers;
 
-  Document(String this.id, String this.type, Content this.content)
+  Document(String this.id, String this.type)
     : version = 0,
       log = new List<Operation>(),
       _handlers = new List<DocumentChangeHandler>() {
-    content.controller.stream.listen((ContentChangeEvent e) {
-      _fireUpdate(new DocumentChangeEvent(this, e));
-    });
   }
 
   void addChangeHandler(DocumentChangeHandler handler) {
@@ -60,10 +44,13 @@ class Document {
     _handlers.add(handler);
   }
 
-  void _fireUpdate(DocumentChangeEvent event) {
+  void fireUpdate(DocumentChangeEvent event) {
     print("fireUpdate");
     _handlers.forEach((handler) { handler(event); });
   }
+
+  String serialize();
+  void deserialize(String data);
 }
 
 /*

--- a/lib/document.dart
+++ b/lib/document.dart
@@ -18,6 +18,7 @@ part of collab;
 abstract class DocumentType {
   String get id;
   Document create(String id);
+  Message parseMessage(Map json);
   Operation transform(Operation op, Operation by);
 }
 

--- a/lib/document.dart
+++ b/lib/document.dart
@@ -18,8 +18,8 @@ part of collab;
 abstract class DocumentType {
   String get id;
   Document create(String id);
-  Message parseMessage(Map json);
-  Operation transform(Operation op, Operation by);
+  Map<String, MessageFactory> get messageFactories;
+  Map<TransformType, Transform> get transforms;
 }
 
 class DocumentChangeEvent {

--- a/lib/document.dart
+++ b/lib/document.dart
@@ -18,14 +18,13 @@ part of collab;
 abstract class ContentChangeEvent {}
 
 abstract class Content {
-  StreamController<ContentChangeEvent> _controller;
+  StreamController<ContentChangeEvent> controller;
 
   Content()
-    : _controller = new StreamController<ContentChangeEvent>();
+    : controller = new StreamController<ContentChangeEvent>();
 
   String serialize();
   void deserialize(String data);
-  Stream<ContentChangeEvent> get changes => _controller.stream;
 }
 
 typedef Content ContentFactory();
@@ -50,7 +49,7 @@ class Document {
     : version = 0,
       log = new List<Operation>(),
       _handlers = new List<DocumentChangeHandler>() {
-    content.changes.listen((ContentChangeEvent e) {
+    content.controller.stream.listen((ContentChangeEvent e) {
       _fireUpdate(new DocumentChangeEvent(this, e));
     });
   }

--- a/lib/document.dart
+++ b/lib/document.dart
@@ -15,7 +15,10 @@ part of collab;
 //  limitations under the License.
 
 
-typedef Document DocumentFactory(String id);
+abstract class DocumentType {
+  String get id;
+  Document create(String id);
+}
 
 class DocumentChangeEvent {
   final Document document;
@@ -26,17 +29,18 @@ class DocumentChangeEvent {
 typedef void DocumentChangeHandler(DocumentChangeEvent e);
 
 abstract class Document {
-  final String type;
   final String id;
   int version;
   final List<Operation> log;
   final List<DocumentChangeHandler> _handlers;
 
-  Document(String this.id, String this.type)
+  Document(String this.id)
     : version = 0,
       log = new List<Operation>(),
       _handlers = new List<DocumentChangeHandler>() {
   }
+
+  DocumentType get type;
 
   void addChangeHandler(DocumentChangeHandler handler) {
     assert(handler != null);

--- a/lib/document.dart
+++ b/lib/document.dart
@@ -19,7 +19,7 @@ abstract class DocumentType {
   String get id;
   Document create(String id);
   Map<String, MessageFactory> get messageFactories;
-  Map<TransformType, Transform> get transforms;
+  Map<String, Map<String, Transform>> get transforms;
 }
 
 class DocumentChangeEvent {

--- a/lib/message.dart
+++ b/lib/message.dart
@@ -79,8 +79,8 @@ class Message {
 
 typedef Message MessageFactory(Map<String, Object> map);
 
-class SystemMessageParser {
-  static final Map<String, MessageFactory> _messageFactories = {
+class SystemMessageFactories {
+  static Map<String, MessageFactory> messageFactories = {
     "log": (m) => new LogMessage.fromMap(m),
     "create": (m) => new CreateMessage.fromMap(m),
     "created": (m) => new CreatedMessage.fromMap(m),
@@ -89,19 +89,4 @@ class SystemMessageParser {
     "close": (m) => new CloseMessage.fromMap(m),
     "snapshot": (m) => new SnapshotMessage.fromMap(m),
   };
-
-  /**
-   * Parses [json] and returns the correct subtype of [Message].
-   *
-   * In order for parse() to return the correct Message subtype a factory
-   * function must be registered.
-   */
-  static Message parse(Map json) {
-    String type = json['type'];
-    var factory = _messageFactories[type];
-    if (factory != null) {
-      return factory(json);
-    }
-    return null;
-  }
 }

--- a/lib/message.dart
+++ b/lib/message.dart
@@ -24,7 +24,7 @@ String SERVER_ID = "_server";
 /**
  * Deserialize JSON messages to [Map]s.
  */
-final StreamTransformer<dynamic, Map> JSON_TO_MAP =
+final StreamTransformer<dynamic, Map> jsonToMap =
     new StreamTransformer(handleData: (value, sink) {
       var json = JSON.parse(value);
       if (json is! Map) {

--- a/lib/message.dart
+++ b/lib/message.dart
@@ -23,6 +23,13 @@ typedef Message MessageFactory(Map<String, Object> map);
 
 String SERVER_ID = "_server";
 
+// TODO temporary until DocumentTypes handle deserialization
+final StreamTransformer<dynamic, Message> MSG_TRANSFORMER =
+    new StreamTransformer(handleData: (value, sink) {
+      var message = new Message.parse(value);
+      sink.add(message);
+    });
+
 /**
  * Messages are sent between clients and servers.
  */

--- a/lib/operation.dart
+++ b/lib/operation.dart
@@ -14,15 +14,6 @@ part of collab;
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-typedef Operation TransformFunc(Operation op1, Operation op2);
-
-class Transform {
-  final Operation op1;
-  final Operation op2;
-  final TransformFunc transform;
-  Transform(this.op1, this.op2, this.transform);
-}
-
 /*
  * Operations modify a document.
  */

--- a/lib/operation.dart
+++ b/lib/operation.dart
@@ -39,3 +39,11 @@ abstract class Operation extends Message {
 
   void apply(Document document);
 }
+
+class TransformType {
+  final String op1Type;
+  final String op2Type;
+  TransformType(this.op1Type, this.op2Type);
+}
+
+typedef Transform(Operation op1, Operation op2);

--- a/lib/operation.dart
+++ b/lib/operation.dart
@@ -40,10 +40,4 @@ abstract class Operation extends Message {
   void apply(Document document);
 }
 
-class TransformType {
-  final String op1Type;
-  final String op2Type;
-  TransformType(this.op1Type, this.op2Type);
-}
-
 typedef Transform(Operation op1, Operation op2);

--- a/lib/operation.dart
+++ b/lib/operation.dart
@@ -14,43 +14,19 @@ part of collab;
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+typedef Operation TransformFunc(Operation op1, Operation op2);
 
-typedef Operation Transform(Operation op1, Operation op2);
+class Transform {
+  final Operation op1;
+  final Operation op2;
+  final TransformFunc transform;
+  Transform(this.op1, this.op2, this.transform);
+}
 
 /*
  * Operations modify a document.
  */
 abstract class Operation extends Message {
-
-  static Map<String, Map<String, Transform>> _getTransforms() => {
-    "text": {"text": TextOperation.transformInsert},
-  };
-
-  /*
-   * Transform [Operation] [op] by [by].
-   *
-   * It's important that these sequences of operation result in the same
-   * changes:
-   *
-   * op1.apply(doc);
-   * var op2t = Operation.transform(op2, op1);
-   * op2t.apply(doc);
-   *
-   * op2.apply(doc);
-   * var op1t = Operation.transform(op1, op2);
-   * op1t.apply(doc);
-   */
-  static Operation transform(Operation op, Operation by) {
-    if (_getTransforms()[op.type] == null) {
-      return op;
-    }
-    Transform t = _getTransforms()[op.type][by.type];
-    if (t == null) {
-      return op;
-    }
-    return t(op, by);
-  }
-
   final String docId;
   // set when op created to the doc version of the client updated when
   // operations from this client that are ahead of this op are applied

--- a/lib/operation.dart
+++ b/lib/operation.dart
@@ -70,5 +70,5 @@ abstract class Operation extends Message {
   Map<String, Object> toMap([values]) => super.toMap(mergeMaps(values, {
       'docId': docId, 'docVersion': docVersion, 'sequence': sequence}));
 
-  void apply(Content content);
+  void apply(Document document);
 }

--- a/lib/operation.dart
+++ b/lib/operation.dart
@@ -70,5 +70,5 @@ abstract class Operation extends Message {
   Map<String, Object> toMap([values]) => super.toMap(mergeMaps(values, {
       'docId': docId, 'docVersion': docVersion, 'sequence': sequence}));
 
-  void apply(Document document);
+  void apply(Content content);
 }

--- a/lib/server/connection.dart
+++ b/lib/server/connection.dart
@@ -15,24 +15,12 @@ part of server;
 //  limitations under the License.
 
 class WebSocketConnection implements Connection {
-  static final StreamTransformer<dynamic, Message> _jsonToMessage =
-      new StreamTransformer(handleData: (value, sink) {
-        var message = new Message.parse(value);
-        sink.add(message);
-      });
-
-  static final StreamTransformer<Message, String> _messageToJson =
-      new StreamTransformer(handleData: (value, sink) {
-        sink.add(value.json);
-      });
-
   final WebSocket _socket;
 
   WebSocketConnection(WebSocket this._socket);
 
-  Stream<Message> get stream => _jsonToMessage.bind(_socket);
-  void add(Message message) => _socket.add(message.json);
-  void addStream(Stream<Message> stream) =>
-      _socket.addStream(_messageToJson.bind(stream));
+  Stream get stream => _socket;
+  void add(String json) => _socket.add(json);
+  void addStream(Stream<String> stream) => _socket.addStream(stream);
   void close() => _socket.close();
 }

--- a/lib/server/connection.dart
+++ b/lib/server/connection.dart
@@ -21,6 +21,6 @@ class WebSocketConnection implements Connection {
 
   Stream get stream => _socket;
   void add(String json) => _socket.add(json);
-  void addStream(Stream<String> stream) => _socket.addStream(stream);
-  void close() => _socket.close();
+  void addStream(Stream<String> stream) { _socket.addStream(stream); }
+  void close() { _socket.close(); }
 }

--- a/lib/server/server.dart
+++ b/lib/server/server.dart
@@ -28,8 +28,8 @@ part 'connection.dart';
 class CollabServer {
   // clientId -> connection
   final Map<String, Connection> _connections;
-  // docType -> DocumentFactory
-  final Map<String, DocumentFactory> _factories;
+  // docTypeId -> DocumentType
+  final Map<String, DocumentType> _docTypes;
   // docId -> document
   final Map<String, Document> _documents;
   // docId -> clientId
@@ -38,7 +38,7 @@ class CollabServer {
 
   CollabServer()
     : _connections = new Map<String, Connection>(),
-      _factories = new Map<String, DocumentFactory>(),
+      _docTypes = new Map<String, DocumentType>(),
       _documents = new Map<String, Document>(),
       _listeners = new Map<String, Set<String>>(),
       _queue = new Queue<Message>() {
@@ -62,8 +62,8 @@ class CollabServer {
     connection.add(message.json);
   }
 
-  void registerDocumentType(String docType, DocumentFactory factory) {
-    _factories[docType] = factory;
+  void registerDocumentType(String docTypeId, DocumentType docType) {
+    _docTypes[docTypeId] = docType;
   }
 
   void _enqueue(Message message) {
@@ -175,12 +175,12 @@ class CollabServer {
 
   void create(String clientId, CreateMessage message) {
     var d = _create(randomId(), message.docType);
-    CreatedMessage m = new CreatedMessage(d.id, d.type, message.id);
+    CreatedMessage m = new CreatedMessage(d.id, d.type.id, message.id);
     _send(clientId, m);
   }
 
-  Document _create(String docId, String docType) {
-    Document d = _factories[docType](docId);
+  Document _create(String docId, String docTypeId) {
+    Document d = _docTypes[docTypeId].create(docId);
     _documents[d.id] = d;
     return d;
   }

--- a/lib/server/server.dart
+++ b/lib/server/server.dart
@@ -68,8 +68,8 @@ class CollabServer {
     connection.add(message.json);
   }
 
-  void registerDocumentType(String docTypeId, DocumentType docType) {
-    _docTypes[docTypeId] = docType;
+  void registerDocumentType(DocumentType docType) {
+    _docTypes[docType.id] = docType;
     _messageFactories.addAll(docType.messageFactories);
     _transforms.addAll(docType.transforms);
   }

--- a/lib/server/server.dart
+++ b/lib/server/server.dart
@@ -51,7 +51,7 @@ class CollabServer {
   void addConnection(Connection connection) {
     String clientId = randomId();
     _connections[clientId] = connection;
-    connection.stream.transform(JSON_TO_MAP).listen((json) {
+    connection.stream.transform(jsonToMap).listen((json) {
       var factory = _messageFactories[json['type']];
       var message = factory(json);
       _enqueue(message);

--- a/lib/server/server.dart
+++ b/lib/server/server.dart
@@ -121,7 +121,7 @@ class CollabServer {
     for (int i = doc.log.length - 1; i >= 0; i--) {
       Operation appliedOp = doc.log[i];
       if (appliedOp.sequence > op.docVersion) {
-        transformed = Operation.transform(transformed, appliedOp);
+        transformed = doc.type.transform(transformed, appliedOp);
       }
     }
     doc.version++;

--- a/lib/server/server.dart
+++ b/lib/server/server.dart
@@ -47,8 +47,15 @@ class CollabServer {
   void addConnection(Connection connection) {
     String clientId = randomId();
     _connections[clientId] = connection;
-    connection.stream.transform(MSG_TRANSFORMER).listen((Message msg) {
-      _enqueue(msg);
+    connection.stream.transform(JSON_TO_MAP).listen((json) {
+      var message = SystemMessageParser.parse(json);
+      if (message == null) {
+        Document doc = _documents[json['docId']];
+        if (doc != null) {
+          message = doc.type.parseMessage(json);
+        }
+      }
+      _enqueue(message);
     },
     onDone: () {
       print("closed: $clientId");

--- a/lib/server/server.dart
+++ b/lib/server/server.dart
@@ -32,7 +32,7 @@ class CollabServer {
   final Map<String, DocumentType> _docTypes;
   // messageType -> MessageFactory
   final Map<String, MessageFactory> _messageFactories;
-  final Map<TransformType, Transform> _transforms;
+  final Map<String, Map<String, Transform>> _transforms;
   // docId -> document
   final Map<String, Document> _documents;
   // docId -> clientId
@@ -42,13 +42,11 @@ class CollabServer {
   CollabServer()
     : _connections = new Map<String, Connection>(),
       _docTypes = new Map<String, DocumentType>(),
-      _messageFactories = new Map<String, MessageFactory>(),
-      _transforms = new Map<TransformType, Transform>(),
+      _messageFactories = new Map.from(SystemMessageFactories.messageFactories),
+      _transforms = new Map<String, Map<String, Transform>>(),
       _documents = new Map<String, Document>(),
       _listeners = new Map<String, Set<String>>(),
-      _queue = new Queue<Message>() {
-    _messageFactories.addAll(SystemMessageFactories.messageFactories);
-  }
+      _queue = new Queue<Message>();
 
   void addConnection(Connection connection) {
     String clientId = randomId();
@@ -131,8 +129,7 @@ class CollabServer {
     for (int i = doc.log.length - 1; i >= 0; i--) {
       Operation appliedOp = doc.log[i];
       if (appliedOp.sequence > op.docVersion) {
-        Transform t =
-            _transforms[new TransformType(transformed.type, appliedOp.type)];
+        Transform t = _transforms[transformed.type][appliedOp.type];
         transformed = (t == null) ? transformed : t(transformed, appliedOp);
       }
     }

--- a/lib/server/server.dart
+++ b/lib/server/server.dart
@@ -156,7 +156,7 @@ class CollabServer {
     _listeners.putIfAbsent(docId, () => new Set<String>());
     _listeners[docId].add(clientId);
     Document d = _documents[docId];
-    SnapshotMessage m = new SnapshotMessage(SERVER_ID, docId, d.text, d.version);
+    Message m = new SnapshotMessage(SERVER_ID, docId, d.version, d.content);
     _send(clientId, m);
   }
 
@@ -172,7 +172,7 @@ class CollabServer {
   }
 
   Document _create(String docId) {
-    Document d = new Document(docId);
+    Document d = new TextDocument(docId);
     _documents[d.id] = d;
     return d;
   }

--- a/lib/server/server.dart
+++ b/lib/server/server.dart
@@ -28,7 +28,7 @@ class CollabServer {
   // clientId -> connection
   final Map<String, Connection> _connections;
   // docType -> DocumentFactory
-  final Map<String, ContentFactory> _factories;
+  final Map<String, DocumentFactory> _factories;
   // docId -> document
   final Map<String, Document> _documents;
   // docId -> clientId
@@ -37,7 +37,7 @@ class CollabServer {
 
   CollabServer()
     : _connections = new Map<String, Connection>(),
-      _factories = new Map<String, ContentFactory>(),
+      _factories = new Map<String, DocumentFactory>(),
       _documents = new Map<String, Document>(),
       _listeners = new Map<String, Set<String>>(),
       _queue = new Queue<Message>() {
@@ -61,7 +61,7 @@ class CollabServer {
     connection.add(message);
   }
 
-  void registerDocumentType(String docType, ContentFactory factory) {
+  void registerDocumentType(String docType, DocumentFactory factory) {
     _factories[docType] = factory;
   }
 
@@ -125,7 +125,7 @@ class CollabServer {
     }
     doc.version++;
     transformed.sequence = doc.version;
-    transformed.apply(doc.content);
+    transformed.apply(doc);
     doc.log.add(transformed);
     _broadcast(transformed);
   }
@@ -163,7 +163,7 @@ class CollabServer {
     _listeners[docId].add(clientId);
     Document d = _documents[docId];
     Message m =
-        new SnapshotMessage(SERVER_ID, docId, d.version, d.content.serialize());
+        new SnapshotMessage(SERVER_ID, docId, d.version, d.serialize());
     _send(clientId, m);
   }
 
@@ -179,8 +179,7 @@ class CollabServer {
   }
 
   Document _create(String docId, String docType) {
-    Content c = _factories[docType]();
-    Document d = new Document(docId, docType, c);
+    Document d = _factories[docType](docId);
     _documents[d.id] = d;
     return d;
   }

--- a/lib/server/server.dart
+++ b/lib/server/server.dart
@@ -18,6 +18,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:io';
 import 'dart:isolate';
+import 'dart:json' as JSON;
 
 import 'package:collab/collab.dart';
 import 'package:collab/utils.dart';
@@ -46,8 +47,8 @@ class CollabServer {
   void addConnection(Connection connection) {
     String clientId = randomId();
     _connections[clientId] = connection;
-    connection.stream.listen((Message message) {
-      _enqueue(message);
+    connection.stream.transform(MSG_TRANSFORMER).listen((Message msg) {
+      _enqueue(msg);
     },
     onDone: () {
       print("closed: $clientId");
@@ -58,7 +59,7 @@ class CollabServer {
       _removeConnection(clientId);
     });
     ClientIdMessage message = new ClientIdMessage(SERVER_ID, clientId);
-    connection.add(message);
+    connection.add(message.json);
   }
 
   void registerDocumentType(String docType, DocumentFactory factory) {
@@ -148,7 +149,7 @@ class CollabServer {
       _connections.remove(clientId);
       return;
     }
-    connection.add(message);
+    connection.add(message.json);
   }
 
   void _open(String clientId, String docId, String docType) {

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -37,7 +37,7 @@ class TextContent extends Content {
     sb.write(_content.substring(pos + del.length));
     _content = sb.toString();
     var event = new TextChangeEvent(pos, del, ins, _content);
-    _controller.add(event);
+    controller.add(event);
   }
 
   String serialize() => _content;

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -15,6 +15,57 @@ part of collab;
 //  limitations under the License.
 
 /*
+ * A simple text-based document.
+ */
+class TextDocument extends Document {
+  String _text;
+
+  TextDocument(String id)
+    : super(id),
+      _text = "";
+
+  String get content => _text;
+
+  void set content(String content) {
+    assert(content != null);
+    modify(0, _text, content);
+  }
+
+  void modify(int position, String deleted, String inserted) {
+    if ((position < 0) || (position > _text.length)) {
+      throw "illegal position: $position, ${_text.length} text: $_text";
+    }
+    StringBuffer sb = new StringBuffer();
+    sb.write(_text.substring(0, position));
+    sb.write(inserted);
+    sb.write(_text.substring(position + deleted.length));
+    _text = sb.toString();
+    DocumentChangeEvent event =
+        new TextChangeEvent(this, position, deleted, inserted, _text);
+    _fireUpdate(event);
+  }
+
+  String toString() => "Document {id: $id, text: $_text}";
+}
+
+/*
+ * Describes a change to a body of text.
+ */
+class TextChangeEvent extends DocumentChangeEvent {
+  final int position;
+  final String deleted;
+  final String inserted;
+  final String text;
+
+  TextChangeEvent(Document document, this.position, this.deleted,
+      this.inserted, this.text)
+    : super(document);
+
+  String toString() =>
+      "TextDocumentChangeEvent {$position, $deleted, $inserted}";
+}
+
+/*
  * Inserts a string into a text document.
  */
 class TextOperation extends Operation {
@@ -35,7 +86,7 @@ class TextOperation extends Operation {
   toMap([values]) => super.toMap(mergeMaps(values, {
       'position': position, 'deleted': deleted, 'inserted': inserted}));
 
-  void apply(Document document) {
+  void apply(TextDocument document) {
     document.modify(position, deleted, inserted);
   }
 

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -14,14 +14,16 @@ part of collab;
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+Document textDocFactory(String id, String type) => new TextDocument(id, type);
+
 /*
  * A simple text-based document.
  */
 class TextDocument extends Document {
   String _text;
 
-  TextDocument(String id)
-    : super(id),
+  TextDocument(String id, String type)
+    : super(id, type),
       _text = "";
 
   String get content => _text;

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -14,20 +14,30 @@ part of collab;
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+class TextDocumentType extends DocumentType {
+  static final TextDocumentType _INSTANCE = new TextDocumentType();
+
+  String get id => "text";
+
+  TextDocument create(String id) {
+    return new TextDocument(id);
+  }
+}
+
 /*
  * A simple text-based document.
  */
 class TextDocument extends Document {
-  static TextDocument factory(String id) => new TextDocument(id);
-
   String _content;
 
   TextDocument(String id)
     : this._content = "",
-      super(id, "text");
+      super(id);
 
   TextDocument.fromString(String id, String this._content)
-    : super(id, "text");
+    : super(id);
+
+  DocumentType get type => TextDocumentType._INSTANCE;
 
   void modify(int pos, String del, String ins) {
     if ((pos < 0) || (pos > _content.length)) {

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -22,6 +22,24 @@ class TextDocumentType extends DocumentType {
   TextDocument create(String id) {
     return new TextDocument(id);
   }
+
+  Operation transform(Operation op, Operation by) {
+    if ((op.type == "text") && (by.type == "text")) {
+      return _transformInsert(op, by);
+    }
+    return op;
+  }
+
+  static TextOperation _transformInsert(TextOperation op, TextOperation by) {
+    int newPosition = (by.position < op.position)
+        ? op.position + (by.inserted.length - by.deleted.length)
+        : op.position;
+    // should docVersion be updated?
+    // should [by] have to have a sequence number?
+    // A: yes, and it should be less than op.docVersion
+    return new TextOperation(op.senderId, op.docId, op.docVersion, newPosition,
+        op.deleted, op.inserted);
+  }
 }
 
 /*
@@ -96,16 +114,5 @@ class TextOperation extends Operation {
 
   void apply(TextDocument document) {
     document.modify(position, deleted, inserted);
-  }
-
-  static TextOperation transformInsert(TextOperation op, TextOperation by) {
-    int newPosition = (by.position < op.position)
-        ? op.position + (by.inserted.length - by.deleted.length)
-        : op.position;
-    // should docVersion be updated?
-    // should [by] have to have a sequence number?
-    // A: yes, and it should be less than op.docVersion
-    return new TextOperation(op.senderId, op.docId, op.docVersion, newPosition,
-        op.deleted, op.inserted);
   }
 }

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -17,15 +17,17 @@ part of collab;
 /*
  * A simple text-based document.
  */
-class TextContent extends Content {
-  static TextContent factory() => new TextContent();
+class TextDocument extends Document {
+  static TextDocument factory(String id) => new TextDocument(id);
 
   String _content;
 
-  TextContent()
-    : this._content = "";
+  TextDocument(String id)
+    : this._content = "",
+      super(id, "text");
 
-  TextContent.fromString(String this._content);
+  TextDocument.fromString(String id, String this._content)
+    : super(id, "text");
 
   void modify(int pos, String del, String ins) {
     if ((pos < 0) || (pos > _content.length)) {
@@ -36,8 +38,8 @@ class TextContent extends Content {
     sb.write(ins);
     sb.write(_content.substring(pos + del.length));
     _content = sb.toString();
-    var event = new TextChangeEvent(pos, del, ins, _content);
-    controller.add(event);
+    var event = new TextChangeEvent(this, pos, del, ins, _content);
+    fireUpdate(event);
   }
 
   String serialize() => _content;
@@ -47,15 +49,18 @@ class TextContent extends Content {
 /*
  * Describes a change to a body of text.
  */
-class TextChangeEvent extends ContentChangeEvent {
+class TextChangeEvent extends DocumentChangeEvent {
   final int position;
   final String deleted;
   final String inserted;
   final String text;
 
-  TextChangeEvent(this.position, this.deleted, this.inserted, this.text);
+  TextChangeEvent(Document document, this.position, this.deleted, this.inserted,
+      this.text)
+    : super(document);
 
-  String toString() => "TextChangeEvent {$position, $deleted, $inserted}";
+  String toString() =>
+      "TextChangeEvent {$document.id, $position, $deleted, $inserted}";
 }
 
 /*
@@ -79,8 +84,8 @@ class TextOperation extends Operation {
   toMap([values]) => super.toMap(mergeMaps(values, {
       'position': position, 'deleted': deleted, 'inserted': inserted}));
 
-  void apply(TextContent content) {
-    content.modify(position, deleted, inserted);
+  void apply(TextDocument document) {
+    document.modify(position, deleted, inserted);
   }
 
   static TextOperation transformInsert(TextOperation op, TextOperation by) {

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -23,6 +23,14 @@ class TextDocumentType extends DocumentType {
     return new TextDocument(id);
   }
 
+  Message parseMessage(Map json) {
+    String type = json['type'];
+    if (type == "text") {
+      return new TextOperation.fromMap(json);
+    }
+    return null;
+  }
+
   Operation transform(Operation op, Operation by) {
     if ((op.type == "text") && (by.type == "text")) {
       return _transformInsert(op, by);

--- a/lib/text/text.dart
+++ b/lib/text/text.dart
@@ -26,19 +26,15 @@ class TextDocumentType extends DocumentType {
     return new TextDocument(id);
   }
 
-  Message parseMessage(Map json) {
-    String type = json['type'];
-    if (type == "text") {
-      return new TextOperation.fromMap(json);
-    }
-    return null;
-  }
+  Map<String, MessageFactory> get messageFactories => {
+    "text": (m) => new TextOperation.fromMap(m)
+  };
 
-  Operation transform(Operation op, Operation by) {
-    if ((op.type == "text") && (by.type == "text")) {
-      return _transformInsert(op, by);
-    }
-    return op;
+  Map<TransformType, Transform> get transforms {
+    var transforms = new Map();
+    transforms[new TransformType("text", "text")] =
+        (op1, op2) => _transformInsert(op1, op2);
+    return transforms;
   }
 
   static TextOperation _transformInsert(TextOperation op, TextOperation by) {

--- a/lib/text/text.dart
+++ b/lib/text/text.dart
@@ -1,5 +1,3 @@
-part of collab;
-
 //  Copyright 2011 Google Inc. All Rights Reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +11,11 @@ part of collab;
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
+
+library text;
+
+import 'package:collab/collab.dart';
+import 'package:collab/utils.dart';
 
 class TextDocumentType extends DocumentType {
   static final TextDocumentType _INSTANCE = new TextDocumentType();

--- a/lib/text/text.dart
+++ b/lib/text/text.dart
@@ -30,12 +30,9 @@ class TextDocumentType extends DocumentType {
     "text": (m) => new TextOperation.fromMap(m)
   };
 
-  Map<TransformType, Transform> get transforms {
-    var transforms = new Map();
-    transforms[new TransformType("text", "text")] =
-        (op1, op2) => _transformInsert(op1, op2);
-    return transforms;
-  }
+  Map<String, Map<String, Transform>> get transforms => {
+    "text" : { "text": (op1, op2) => _transformInsert(op1, op2) }
+  };
 
   static TextOperation _transformInsert(TextOperation op, TextOperation by) {
     int newPosition = (by.position < op.position)


### PR DESCRIPTION
This adds support for multiple document types in dart-collab. 

Implementors of additional document types will implement Document and DocumentType subclasses, as well as the message parsers and operation transforms required for the new document type.

This change breaks out the existing text document implementation into a new package, text with the implementation renamed to TextDocument.
